### PR TITLE
Fix: Handle cases where "Next page" button is missing

### DIFF
--- a/slack-search-result-exporter.user.js
+++ b/slack-search-result-exporter.user.js
@@ -129,7 +129,13 @@
         nextArrowBtnElement = e;
       }
     });
-      messagePack.hasNextPage = !nextArrowBtnElement.outerHTML.includes("disabled");
+    if (!nextArrowBtnElement) {
+      log("createPromiseClickNextButton | Next page button not found.");
+      return new Promise((resolve) => {
+        resolve(messagePack);
+      });
+    }
+    messagePack.hasNextPage = !nextArrowBtnElement.outerHTML.includes("disabled");
     if (!messagePack.hasNextPage) {
       log("createPromiseClickNextButton | messagePack.hasNextPage = " + messagePack.hasNextPage);
       /* Return dummy promise */


### PR DESCRIPTION
In my use case, the script failed when the "Next page" button was not present in the DOM. This change adds a check to gracefully skip navigation when the button is missing, improving reliability.

 - Added check in createPromiseClickNextButton to handle missing button.